### PR TITLE
Update gemspec to support omniauth 1 and 2

### DIFF
--- a/omniauth-chef-oauth2.gemspec
+++ b/omniauth-chef-oauth2.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'
 
-  spec.add_dependency 'omniauth', '~> 1.0'
+  spec.add_dependency 'omniauth',   ['>= 1.9', '< 3']
   spec.add_dependency 'omniauth-oauth2', '~> 1.0'
 end


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef Supermaket is using this gem. There ominauth has to upgraded to 2.0.0. Currently only `ominauth 1.0`  is supported for this gem, hence updating the dependency requirement to ` ['>= 1.9', '< 3']` so that even omniauth 2.0.0 is also supported

## Related Issue
https://github.com/chef/supermarket/issues/1903

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] Allnew and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
